### PR TITLE
Migrating to jni-rs 0.21 (fix #1)

### DIFF
--- a/catch_panic/Cargo.toml
+++ b/catch_panic/Cargo.toml
@@ -24,6 +24,6 @@ jni = "0"
 catch_panic_macros = { version = "1.0.0", path = "../catch_panic_macros" }
 
 [dev-dependencies]
-jni = { version = "0", features = ["invocation"] }
+jni = { version = "0.21.1", features = ["invocation"] }
 catch_panic = { path = ".", features = ["internal-doctests"] }
 trybuild = "1.0.63"

--- a/catch_panic/src/handler.rs
+++ b/catch_panic/src/handler.rs
@@ -26,7 +26,7 @@ where
 /// `#[catch_panic]`'s default panic handler. This
 /// will rethrow all caught panics as java `RuntimeException`s
 /// with the message passed to `panic!`.
-pub fn default_handler(env: JNIEnv, err: Box<dyn Any + Send + 'static>) {
+pub fn default_handler(mut env: JNIEnv, err: Box<dyn Any + Send + 'static>) {
     let msg = match err.downcast_ref::<&'static str>() {
         Some(s) => *s,
         None => match err.downcast_ref::<String>() {

--- a/catch_panic/ui_tests/fail/no_jni_env.stderr
+++ b/catch_panic/ui_tests/fail/no_jni_env.stderr
@@ -2,4 +2,4 @@ error: #[catch_panic] requires that this function has at least one argument of t
  --> ui_tests/fail/no_jni_env.rs:4:1
   |
 4 | fn no_jni_env() {
-  | ^^^^^^^^^^^^^^^
+  | ^^

--- a/catch_panic/ui_tests/fail/on_struct.stderr
+++ b/catch_panic/ui_tests/fail/on_struct.stderr
@@ -2,4 +2,4 @@ error: #[catch_panic] can only be applied to functions
  --> ui_tests/fail/on_struct.rs:4:1
   |
 4 | pub struct PanicDonationBox;
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  | ^^^

--- a/catch_panic/ui_tests/fail/wrong_handler_type.stderr
+++ b/catch_panic/ui_tests/fail/wrong_handler_type.stderr
@@ -1,17 +1,22 @@
 error[E0631]: type mismatch in function arguments
-  --> ui_tests/fail/wrong_handler_type.rs:9:25
-   |
-4  | pub fn trust_me(_env: JNIEnv, err: String) {
-   | ------------------------------------------ found signature of `for<'r> fn(JNIEnv<'r>, String) -> _`
+ --> ui_tests/fail/wrong_handler_type.rs:9:25
+  |
+4 | pub fn trust_me(_env: JNIEnv, err: String) {
+  | ------------------------------------------ found signature defined here
 ...
-9  | #[catch_panic(handler = "trust_me")]
-   | ------------------------^^^^^^^^^^--
-   | |                       |
-   | |                       expected signature of `for<'r> fn(JNIEnv<'r>, Box<(dyn Any + Send + 'static)>) -> _`
-   | required by a bound introduced by this call
-   |
+9 | #[catch_panic(handler = "trust_me")]
+  | ------------------------^^^^^^^^^^--
+  | |                       |
+  | |                       expected due to this
+  | required by a bound introduced by this call
+  |
+  = note: expected function signature `for<'a> fn(JNIEnv<'a>, Box<(dyn Any + Send + 'static)>) -> _`
+             found function signature `for<'a> fn(JNIEnv<'a>, String) -> _`
 note: required by a bound in `__catch_panic`
-  --> src/handler.rs
-   |
-   |     H: FnOnce(JNIEnv, Box<dyn Any + Send + 'static>),
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `__catch_panic`
+ --> src/handler.rs
+  |
+  | pub fn __catch_panic<F, R, H>(env: JNIEnv, default: R, handler: H, f: F) -> R
+  |        ------------- required by a bound in this function
+...
+  |     H: FnOnce(JNIEnv, Box<dyn Any + Send + 'static>),
+  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `__catch_panic`


### PR DESCRIPTION
After jni-rs 0.21, `JNIEnv` became `!Copy` and most of its methods receive `&mut self` instead of `&self`.
See https://github.com/jni-rs/jni-rs/blob/master/docs/0.21-MIGRATION.md

This PR use `JNIEnv::unsafe_clone()` to create another env for panic handler. It will fix #1.